### PR TITLE
Always save BlockType fieldLayout

### DIFF
--- a/src/services/BlockTypes.php
+++ b/src/services/BlockTypes.php
@@ -193,13 +193,13 @@ class BlockTypes extends Component
 							$fieldsService->deleteLayoutById($oldBlockType->fieldLayoutId);
 						}
 					}
-
-					$fieldsService->saveLayout($fieldLayout);
-
-					$blockType->fieldLayoutId = $fieldLayout->id;
-					$record->fieldLayoutId = $fieldLayout->id;
 				}
 
+				$fieldsService->saveLayout($fieldLayout);
+
+				$blockType->fieldLayoutId = $fieldLayout->id;
+				$record->fieldLayoutId = $fieldLayout->id;
+				
 				$record->fieldId = $blockType->fieldId;
 				$record->name = $blockType->name;
 				$record->handle = $blockType->handle;


### PR DESCRIPTION
There is no harm in always saving the field layout, even when it already exists. This fixes an issue with Schematic importing Neo before its field layout fields are imported.