### PR TITLE
Fix duplicate blocks from BlockQuery on Craft 3.1

### DIFF
--- a/src/elements/db/BlockQuery.php
+++ b/src/elements/db/BlockQuery.php
@@ -351,7 +351,19 @@ class BlockQuery extends ElementQuery
 
 	// Protected methods
 
-	/**
+    /**
+     * @inheritdoc
+     */
+    protected function afterPrepare(): bool
+    {
+        $this->subQuery->leftJoin('{{%structures}} structures', '[[structureelements.structureId]] = [[structures.id]]');
+        $this->query->leftJoin('{{%structures}} structures', '[[structureelements.structureId]] = [[structures.id]]');
+        $this->query->andWhere(['structures.dateDeleted' => null]);
+        $this->subQuery->andWhere(['structures.dateDeleted' => null]);
+        return parent::afterPrepare();
+    }
+
+    /**
 	 * @inheritdoc
 	 */
 	protected function beforePrepare(): bool


### PR DESCRIPTION
P&T snuck in a last minute change to Craft 3.1 prior to release that adds soft-deletes to structures. This PR fixes an error with the primary element query where joins would produce multiple duplicate records.

This adds a left-join to both the main and subquery as well as additional `where` clauses to not select deleted structures. 

Please test this thoroughly before merging.

Fixes #174 