### PR TITLE
Ensure field layout IDs are set when setting a field's block types

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -162,6 +162,19 @@ class Field extends BaseField implements EagerLoadingFieldInterface
 
 					$fieldLayout = Craft::$app->getFields()->assembleLayout($fieldLayoutPost, $requiredFieldPost);
 					$fieldLayout->type = Block::class;
+
+					// Ensure the field layout ID is set, if it exists
+					$layoutIdResult = (new Query)
+						->select(['fieldLayoutId'])
+						->from('{{%neoblocktypes}}')
+						->where(['id' => $blockTypeId])
+						->one();
+
+					if ($layoutIdResult !== null)
+					{
+						$fieldLayout->id = $layoutIdResult['fieldLayoutId'];
+					}
+
 					$newBlockType->setFieldLayout($fieldLayout);
 				}
 			}


### PR DESCRIPTION
Fixes issue with Field Labels compatibility where, on Neo field settings validation errors, previously existing labels would not be restored to the block types' field layout designers, and a subsequent successful Neo field save would cause those labels to be deleted.

Partially fixes spicywebau/craft-fieldlabels#11