### PR TITLE
fix #218 - assign default siteId in `fields->saveValue()`

### DIFF
--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -220,12 +220,14 @@ class Fields extends Component
 			$transaction = $dbService->beginTransaction();
 			try
 			{
+				$siteId = $query->siteId;
+
 				// If we're duplicating an element, or the owner was a preexisting element,
 				// make sure that the blocks for this field/owner respect the field's translation setting
 				if ($owner->duplicateOf || $query->ownerId)
 				{
 					$ownerId = $owner->duplicateOf ? $owner->duplicateOf->id : $query->ownerId;
-					$siteId = $owner->duplicateOf ? $owner->duplicateOf->siteId : $query->siteId;
+					$siteId = $owner->duplicateOf ? $owner->duplicateOf->siteId : $siteId;
 					$this->_applyFieldTranslationSettings($ownerId, $siteId, $field);
 				}
 


### PR DESCRIPTION
Assign default value to `$siteId` variable in `fields->saveValue()` to avoid error thrown when saving new elements with not-localized neo fields. See #218 for more details.