### PR TITLE
Reset Neo field values after saving new elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Fxed
+- Fix #227 - fixed issue where Neo fields could lose their content when updating to Craft 3.2
+
 ## 2.3.5 - 2019-05-24
 ### Fixed
 - Fix #210 - check if viewing a shared draft so it can retrieve the correct data

--- a/src/Field.php
+++ b/src/Field.php
@@ -604,6 +604,11 @@ class Field extends BaseField implements EagerLoadingFieldInterface
 	{
 		Neo::$plugin->fields->saveValue($this, $element, $isNew);
 
+        // Reset the field value if this is a new element
+        if ($element->duplicateOf || $isNew) {
+            $element->setFieldValue($this->handle, null);
+        }
+
 		parent::afterElementSave($element, $isNew);
 	}
 


### PR DESCRIPTION
This PR replicates the bug fix implemented in craftcms/cms@0a88191394a7f5710338ce73c94ddae831607918, which fixes Neo issue #227.

The tricky part is that by the time someone updates to Craft 3.2 with Neo installed, the damage will already be done, and I’m not sure there’s a good way to retroactively fix the lost block data.

So, instead of adding this fix to the HEAD of the Neo repo, I have created it from a fork off of the `2.3.5` tag – the last version of Neo that supported Craft 3.1.

I suggest you do this:

1. Create a new `2.3.5.1` branch off of the 8fb9afdd986a6a70b7fe252a20e1a429ec6bbe17 commit, and push it to GitHub.
2. Click the “Edit” button at the top of this PR and change the Base to your new branch.
3. Merge the PR, and git-pull the branch.
4. Prepare and tag Neo 2.3.5.1 from that branch.
5. Push the tag to GitHub.
6. Ensure that Neo 2.3.5.1 is available as an update when running Craft 3.1 and Neo <= 2.3.5.
7. Then merge the `2.3.5.1` branch into `master`, where you can prepare and tag a new `2.3.6.1` or `2.3.7` release with the same fix for people running Craft 3.2 and Neo 2.3.6.

That way, people will have the ability to get this Neo fix in at the same time (or before) updating to Craft 3.2, so when Craft 3.2’s “Updating entry drafts and revisions” background job runs, no Neo content will go missing.