### PR TITLE
Fixed issue with blank field layout

### DIFF
--- a/src/integrations/fieldlabels/FieldLabels.php
+++ b/src/integrations/fieldlabels/FieldLabels.php
@@ -42,7 +42,7 @@ class FieldLabels
 			Event::on(BlockTypes::class, BlockTypes::EVENT_AFTER_SAVE_BLOCK_TYPE, function (Event $event) {
 				$postData = Craft::$app->getRequest()->getBodyParam('neo');
 				$blockType = $event->blockType;
-				$layoutFieldIds = Craft::$app->getFields()->getFieldIdsByLayoutId($blockType->fieldLayoutId);
+				$layoutFieldIds = Craft::$app->getFields()->getFieldIdsByLayoutId((int) $blockType->fieldLayoutId);
 				$fieldLabelsPost = null;
 				$doesTheBlockTypeIdKeyExist = null;
 				


### PR DESCRIPTION
Hello!

If a block has no field layout and the label plugin is installed it breaks the site with a typeerror as `getFieldIdsByLayoutId` requires an int. Typecasting it fixes this.