### PR TITLE
Delta updates support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,12 +32,6 @@
       "benf\\neo\\": "src/"
     }
   },
-  "repositories": [
-    {
-      "type": "composer",
-      "url": "https://asset-packagist.org"
-    }
-  ],
   "extra": {
     "handle": "neo",
     "name": "Neo",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "rss": "https://github.com/spicywebau/craft-neo/commits/master.atom"
   },
   "require": {
-    "craftcms/cms": "^3.3.0"
+    "craftcms/cms": "^3.4.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Field.php
+++ b/src/Field.php
@@ -391,9 +391,15 @@ class Field extends BaseField implements EagerLoadingFieldInterface, GqlInlineFr
 		
 		// Set the initially matched elements if $value is already set, which is the case if there was a validation
 		// error or we're loading an entry revision.
-		if (is_array($value) || $value === '') {
+		$elements = null;
+
+		if ($value === '') {
+			$elements = [];
+		} else if ($element && is_array($value)) {
 			$elements = $this->_createBlocksFromSerializedData($value, $element);
-			
+		}
+
+		if ($elements !== null) {
 			if (!Craft::$app->getRequest()->getIsLivePreview()) {
 				$query->anyStatus();
 			} else {
@@ -660,7 +666,7 @@ class Field extends BaseField implements EagerLoadingFieldInterface, GqlInlineFr
 		/** @var Element $element */
 		if ($element->duplicateOf !== null) {
 			Neo::$plugin->fields->duplicateBlocks($this, $element->duplicateOf, $element, true);
-		} else {
+		} else if ($element->isFieldDirty($this->handle)) {
 			Neo::$plugin->fields->saveValue($this, $element);
 		}
 		
@@ -904,100 +910,81 @@ class Field extends BaseField implements EagerLoadingFieldInterface, GqlInlineFr
 	 * Creates Neo blocks out of the given serialized data.
 	 *
 	 * @param array $value The raw field data.
-	 * @param ElementInterface|null $element The element associated with this field, if any.
+	 * @param ElementInterface $element The element associated with this field
 	 * @return array The Blocks created from the given data.
 	 */
-	private function _createBlocksFromSerializedData($value, ElementInterface $element = null): array
+	private function _createBlocksFromSerializedData($value, ElementInterface $element): array
 	{
-		if (!is_array($value)) {
-			return [];
-		}
-		
 		$blockTypes = ArrayHelper::index(Neo::$plugin->blockTypes->getByFieldId($this->id), 'handle');
-		$oldBlocksById = [];
 		
-		if ($element && $element->id) {
-			$ownerId = $element->id;
-			$blockIds = [];
-			
-			foreach (array_keys($value) as $blockId) {
-				if (is_numeric($blockId) && $blockId !== 0) {
-					$blockIds[] = $blockId;
-					
-					// If that block was duplicated earlier in this request, check for that as well.
-					if (isset(Elements::$duplicatedElementIds[$blockId])) {
-						$blockIds[] = Elements::$duplicatedElementIds[$blockId];
-					}
-				}
-			}
-			
-			if (!empty($blockIds)) {
-				$oldBlocksQuery = Block::find();
-				$oldBlocksQuery->fieldId($this->id);
-				$oldBlocksQuery->ownerId($ownerId);
-				$oldBlocksQuery->id($blockIds);
-				$oldBlocksQuery->limit(null);
-				$oldBlocksQuery->anyStatus();
-				$oldBlocksQuery->siteId($element->siteId);
-				$oldBlocksQuery->indexBy('id');
-				$oldBlocksById = $oldBlocksQuery->all();
-			}
+		// Get the old blocks
+		if ($element->id) {
+			$oldBlocksById = Block::find()
+				->fieldId($this->id)
+				->ownerId($element->id)
+				->limit(null)
+				->anyStatus()
+				->siteId($element->siteId)
+				->indexBy('id')
+				->all();
 		} else {
-			$ownerId = null;
+			$oldBlocksById = [];
 		}
 		
-		// Generally, block data will be received with levels starting from 0, so they need to be adjusted up by 1.
-		// For entry revisions and new entry drafts, though, the block data will have levels starting from 1.
-		// Because the first block in a field will always be level 1, we can use that to check whether the count is
-		// starting from 0 or 1 and thus ensure that all blocks display at the correct level.
-		$adjustLevels = false;
+		$fieldNamespace = $element->getFieldParamNamespace();
+		$baseBlockFieldNamespace = $fieldNamespace ? "{$fieldNamespace}.{$this->handle}" : null;
+
+		// Was the value posted in the new (delta) format?
+        if (isset($value['blocks']) || isset($value['sortOrder'])) {
+            $newBlockData = $value['blocks'] ?? [];
+            $newSortOrder = $value['sortOrder'] ?? array_keys($oldBlocksById);
+            if ($baseBlockFieldNamespace) {
+                $baseBlockFieldNamespace .= '.blocks';
+            }
+        } else {
+            $newBlockData = $value;
+            $newSortOrder = array_keys($value);
+        }
+        
+        /** @var Block[] $blocks */
 		$blocks = [];
 		$prevBlock = null;
 		
-		if (!empty($value)) {
-			$firstBlock = reset($value);
-			$firstBlockLevel = (int)$firstBlock['level'];
+		foreach ($newSortOrder as $blockId) {
+			$blockData = $newBlockData[$blockId] ?? [];
 			
-			if ($firstBlockLevel === 0) {
-				$adjustLevels = true;
-			}
-		}
-		
-		foreach ($value as $blockId => $blockData) {
-			
-			if (!isset($blockData['type']) || !isset($blockTypes[$blockData['type']])) {
-				continue;
-			}
-			
-			$blockType = $blockTypes[$blockData['type']];
 			$isEnabled = isset($blockData['enabled']) ? (bool)$blockData['enabled'] : true;
 			$isCollapsed = isset($blockData['collapsed']) ? (bool)$blockData['collapsed'] : false;
 			$isModified = isset($blockData['modified']) ? (bool)$blockData['modified'] : false;
 			
+            // If this is a preexisting block but we don't have a record of it,
+            // check to see if it was recently duplicated.
 			if (
 				strpos($blockId, 'new') !== 0 &&
 				!isset($oldBlocksById[$blockId]) &&
-				isset(Elements::$duplicatedElementIds[$blockId])
+				isset(Elements::$duplicatedElementIds[$blockId]) &&
+				isset($oldBlocksById[Elements::$duplicatedElementIds[$blockId]])
 			) {
 				$blockId = Elements::$duplicatedElementIds[$blockId];
 			}
 			
-			// Is this new? (Or has it been deleted?)
-			if (strpos($blockId, 'new') === 0 || !isset($oldBlocksById[$blockId])) {
-				$block = new Block();
-				$block->fieldId = $this->id;
-				$block->typeId = $blockType->id;
-				$block->ownerId = $ownerId;
-				$block->siteId = $element->siteId;
-			} else {
-				$block = $oldBlocksById[$blockId];
-			}
+			// Existing block?
+			if (isset($oldBlocksById[$blockId])) {
+			    $block = $oldBlocksById[$blockId];
+			    $block->dirty = true;
+            } else {
+			    // Make sure it's a valid block type
+                if (!isset($blockData['type']) || !isset($blockTypes[$blockData['type']])) {
+                    continue;
+                }
+                $block = new Block();
+                $block->fieldId = $this->id;
+                $block->typeId = $blockTypes[$blockData['type']]->id;
+                $block->ownerId = $element->id;
+                $block->siteId = $element->siteId;
+            }
 			
-			$blockLevel = (int)$blockData['level'];
-			
-			if ($adjustLevels) {
-				$blockLevel++;
-			}
+			$blockLevel = (int)($blockData['level'] ?? $block->level);
 			
 			$block->setOwner($element);
 			$block->setCollapsed($isCollapsed);
@@ -1005,21 +992,13 @@ class Field extends BaseField implements EagerLoadingFieldInterface, GqlInlineFr
 			$block->enabled = $isEnabled;
 			$block->level = $blockLevel;
 			
-			$fieldNamespace = $element->getFieldParamNamespace();
-			
-			if ($fieldNamespace !== null) {
-				$blockNamespace = ($fieldNamespace ? $fieldNamespace . '.' : '') . "$this->handle.$blockId.fields";
-				$block->setFieldParamNamespace($blockNamespace);
+            // Set the content post location on the block if we can
+			if ($baseBlockFieldNamespace) {
+				$block->setFieldParamNamespace("{$baseBlockFieldNamespace}.{$blockId}.fields");
 			}
 			
 			if (isset($blockData['fields'])) {
-				foreach ($blockData['fields'] as $fieldHandle => $fieldValue) {
-					try {
-						$block->setFieldValue($fieldHandle, $fieldValue);
-					} catch (UnknownPropertyException $e) {
-						// the field was probably deleted
-					}
-				}
+			    $block->setFieldValues($blockData['fields']);
 			}
 			
 			if ($prevBlock) {
@@ -1030,10 +1009,22 @@ class Field extends BaseField implements EagerLoadingFieldInterface, GqlInlineFr
 			$prevBlock = $block;
 			$blocks[] = $block;
 		}
-		
-		foreach ($blocks as $block) {
-			$block->setAllElements($blocks);
-		}
+
+        if (!empty($blocks)) {
+            // Generally, block data will be received with levels starting from 0, so they need to be adjusted up by 1.
+            // For entry revisions and new entry drafts, though, the block data will have levels starting from 1.
+            // Because the first block in a field will always be level 1, we can use that to check whether the count is
+            // starting from 0 or 1 and thus ensure that all blocks display at the correct level.
+            $adjustLevels = (int)$blocks[0]->level === 0;
+
+            foreach ($blocks as $block) {
+                $block->setAllElements($blocks);
+                
+                if ($adjustLevels && $block->dirty) {
+                    $block->level++;
+                }
+            }
+        }
 		
 		return $blocks;
 	}

--- a/src/elements/Block.php
+++ b/src/elements/Block.php
@@ -154,6 +154,13 @@ class Block extends Element implements BlockElementInterface
 	public $_collapsed;
 
 	/**
+	 * @var bool Whether the block has changed.
+	 * @internal
+	 * @since 2.6.0
+	 */
+	public $dirty = false;
+
+	/**
 	 * @var bool|null Whether this block has been modified.
 	 */
 	private $_modified;

--- a/src/elements/db/BlockQuery.php
+++ b/src/elements/db/BlockQuery.php
@@ -245,6 +245,7 @@ class BlockQuery extends ElementQuery
 
 	/**
 	 * @inheritdoc
+     * @return Block[]|array
 	 */
 	public function all($db = null)
 	{
@@ -260,6 +261,7 @@ class BlockQuery extends ElementQuery
 
 	/**
 	 * @inheritdoc
+     * @return Block|array|null
 	 */
 	public function one($db = null)
 	{
@@ -275,6 +277,7 @@ class BlockQuery extends ElementQuery
 
 	/**
 	 * @inheritdoc
+     * @return Block|array|null
 	 */
 	public function nth(int $n, Connection $db = null)
 	{


### PR DESCRIPTION
Hey Spicy!

Craft 3.4 is adding support for **delta element updates**, meaning that entry, category, and user forms will only submit custom field values that actually changed, giving the back end a chance to optimize the element save process by avoiding saving things that haven’t changed.

Matrix already supports it, and we hope that Neo and Super Table will add support soon as part of a feature branch so people can start testing ahead of the 3.4.0 release.

I started working on adding Neo support for you, but hit a roadblock because the field is built by JavaScript, and I couldn’t find the JS source files in the repo. **I’m hoping that you can take over from here.**

Here’s what’s needed to add full delta update support to Neo:

- [x] Skip post-element save processing in `Field::afterElementPropagate()` if the field isn’t dirty
- [x] Check for alternate POST syntax in `Field::_createBlocksFromSerializedData()`, and if used, stitch POSTed block data with existing block data, keeping track of which blocks are dirty
- [ ] Update the field input
  - [ ] Block inputs should have a `[blocks]` sub-namespace (e.g. `fields[myNeo][blocks][22][fields][myText]` rather than `fields[myNeo][22][fields][myText]`)
  - [ ] Ideally, block sort order & position would be submitted separately from the block data (e.g. `name="fields[myNeo][sortOrder][]" value="<block ID>"` so that entire blocks don’t need to be resaved if only their position changes.
  - The input should start registering a “delta name” for each block (e.g. `myNeo[blocks][22]`), so that element forms know to group their nested inputs together
  - The input should pass `registerDeltas: true` when rendering either `_includes/fields.html` or `_includes/field.html` so that sub-fields get their own delta names as well.
- [ ] `Fields::saveValue()` should start only saving blocks that were marked as dirty by `Field::_createBlocksFromSerializedData()`.

See the diff at https://github.com/craftcms/cms/pull/5146 to see how Matrix was affected by this.

To get Craft 3.4 running locally, change your `craftcms/cms` requirement in `composer.json` to:

```json
"require": {
  "craftcms/cms": "3.4.x-dev",
  "...": "..."
}
```

Then run `composer update`.

Let me know if you have any questions!