### PR TITLE
use `$isModified` variable (prevents error when modified isn't defined)

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -995,7 +995,7 @@ class Field extends BaseField implements EagerLoadingFieldInterface, GqlInlineFr
             // Existing block?
             if (isset($oldBlocksById[$blockId])) {
                 $block = $oldBlocksById[$blockId];
-                $block->dirty = (bool)$blockData['modified'];
+                $block->dirty = $isModified;
                 // $block->dirty = !empty($blockData);
             } else {
                 // Make sure it's a valid block type


### PR DESCRIPTION
When using the SiteCopy plugin (https://github.com/Goldinteractive/craft3-sitecopy) we were getting errors of a missing modified key in the block-data.

The variable `$isModified` is created a few lines before and it uses the same array key and has a fallback for when the key is missing 

