### PR TITLE
fix: disabled blocks cause invalid hierarchy in serialized values

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -404,7 +404,7 @@ class Field extends BaseField implements EagerLoadingFieldInterface, GqlInlineFr
         $serialized = [];
         $new = 0;
         
-        foreach ($value->all() as $block) {
+        foreach ($value->status(null)->all() as $block) {
             $blockId = $block->id ?? 'new' . ++$new;
             $serialized[$blockId] = [
                 'type' => $block->getType()->handle,


### PR DESCRIPTION
The fields `serializeValue()` method includes enabled states for the blocks returned, but only enabled blocks are ever included in the result. Furthermore, enabled blocks are even included if their ancestor is disabled.
This leads to an invalid block hierarchy being returned if one of the blocks in the field's value was disabled, but any of its descendants weren't (which is a perfectly valid use case in the Admin CP as marking a block disabled will visually disable all of its children, too).

Examplary field value resulting in wrong serialization:

- block 1 (enabled)
  - block 1.A (enabled)
  - block 1.B (enabled)
- block 2 (disabled)
  - block 2.A (enabled)

With this structure, `serializeValue()` currently returns a serialized block structure as follows:
- block 1 (enabled, level 1)
    - block 1.A (enabled, level 2)
    - block 1.B (enabled, level 2)
    - block 2.A (enabled, , level 2)

Where it should correctly return:
- block 1 (enabled, level 1)
    - block 1.A (enabled, level 2)
    - block 1.B (enabled, level 2)
- block 2 (disabled, level 1)
    - block 2.A (enabled, , level 2)

Let me know if I am missing something.

Thanks for your great work,
David