### PR TITLE
Allow level in GraphQL blocks query

### DIFF
--- a/src/gql/arguments/elements/Block.php
+++ b/src/gql/arguments/elements/Block.php
@@ -32,6 +32,11 @@ class Block extends ElementArguments
 				'type' => Type::listOf(Type::string()),
 				'description' => 'Narrows the query results based on the neo blocks’ block type handles.'
 			],
+			'level' => [
+				'name' => 'level',
+				'type' => Type::int(),
+				'description' => 'The block’s level within its field'
+			],
 		]);
 	}
 }

--- a/src/gql/interfaces/elements/Block.php
+++ b/src/gql/interfaces/elements/Block.php
@@ -84,7 +84,7 @@ class Block extends Element
 				'name' => 'typeHandle',
 				'type' => Type::string(),
 				'description' => 'The handle of the neo block\'s type.'
-			],
+			]
 		]);
 	}
 }

--- a/src/gql/interfaces/elements/Block.php
+++ b/src/gql/interfaces/elements/Block.php
@@ -89,7 +89,7 @@ class Block extends Element
 				'name' => 'level',
 				'type' => Type::int(),
 				'description' => 'The block’s level within its field'
-            ],
+			],
 		]);
 	}
 }

--- a/src/gql/interfaces/elements/Block.php
+++ b/src/gql/interfaces/elements/Block.php
@@ -26,7 +26,7 @@ class Block extends Element
 	{
 		return BlockType::class;
 	}
-	
+
 	/**
 	 * @inheritdoc
 	 */
@@ -35,7 +35,7 @@ class Block extends Element
 		if ($type = GqlEntityRegistry::getEntity(self::class)) {
 			return $type;
 		}
-		
+
 		$type = GqlEntityRegistry::createEntity(self::class, new InterfaceType([
 			'name' => static::getName(),
 			'fields' => self::class . '::getFieldDefinitions',
@@ -44,14 +44,14 @@ class Block extends Element
 				return $value->getGqlTypeName();
 			}
 		]));
-		
+
 		foreach (BlockType::generateTypes() as $typeName => $generatedType) {
 			TypeLoader::registerType($typeName, function () use ($generatedType) { return $generatedType ;});
 		}
-		
+
 		return $type;
 	}
-	
+
 	/**
 	 * @inheritdoc
 	 */
@@ -59,7 +59,7 @@ class Block extends Element
 	{
 		return 'NeoBlockInterface';
 	}
-	
+
 	/**
 	 * @inheritdoc
 	 */
@@ -84,7 +84,12 @@ class Block extends Element
 				'name' => 'typeHandle',
 				'type' => Type::string(),
 				'description' => 'The handle of the neo block\'s type.'
-			]
+			],
+            'level' => [
+                'name' => 'level',
+                'type' => Type::int(),
+                'description' => 'The block’s level within its field'
+            ],
 		]);
 	}
 }

--- a/src/gql/interfaces/elements/Block.php
+++ b/src/gql/interfaces/elements/Block.php
@@ -85,11 +85,6 @@ class Block extends Element
 				'type' => Type::string(),
 				'description' => 'The handle of the neo block\'s type.'
 			],
-			'level' => [
-				'name' => 'level',
-				'type' => Type::int(),
-				'description' => 'The block’s level within its field'
-			],
 		]);
 	}
 }

--- a/src/gql/interfaces/elements/Block.php
+++ b/src/gql/interfaces/elements/Block.php
@@ -85,10 +85,10 @@ class Block extends Element
 				'type' => Type::string(),
 				'description' => 'The handle of the neo block\'s type.'
 			],
-            'level' => [
-                'name' => 'level',
-                'type' => Type::int(),
-                'description' => 'The block’s level within its field'
+			'level' => [
+				'name' => 'level',
+				'type' => Type::int(),
+				'description' => 'The block’s level within its field'
             ],
 		]);
 	}

--- a/src/gql/interfaces/elements/Block.php
+++ b/src/gql/interfaces/elements/Block.php
@@ -26,7 +26,7 @@ class Block extends Element
 	{
 		return BlockType::class;
 	}
-
+	
 	/**
 	 * @inheritdoc
 	 */
@@ -35,7 +35,7 @@ class Block extends Element
 		if ($type = GqlEntityRegistry::getEntity(self::class)) {
 			return $type;
 		}
-
+		
 		$type = GqlEntityRegistry::createEntity(self::class, new InterfaceType([
 			'name' => static::getName(),
 			'fields' => self::class . '::getFieldDefinitions',
@@ -44,14 +44,14 @@ class Block extends Element
 				return $value->getGqlTypeName();
 			}
 		]));
-
+		
 		foreach (BlockType::generateTypes() as $typeName => $generatedType) {
 			TypeLoader::registerType($typeName, function () use ($generatedType) { return $generatedType ;});
 		}
-
+		
 		return $type;
 	}
-
+	
 	/**
 	 * @inheritdoc
 	 */
@@ -59,7 +59,7 @@ class Block extends Element
 	{
 		return 'NeoBlockInterface';
 	}
-
+	
 	/**
 	 * @inheritdoc
 	 */


### PR DESCRIPTION
When you query a neo field in Graphql, all block levels (not just top level) will be queried. This pull request allow to pass the level you want to query (for example: `blocks(level: 1)` for top level blocks only).