### PR TITLE
Fix migration for PostgreSQL

### DIFF
--- a/src/migrations/m201208_110049_delete_blocks_without_sort_order.php
+++ b/src/migrations/m201208_110049_delete_blocks_without_sort_order.php
@@ -35,7 +35,7 @@ class m201208_110049_delete_blocks_without_sort_order extends Migration
         $neoBlockIds = (new Query())
             ->select(['id'])
             ->from('{{%neoblocks}}')
-            ->where('sortOrder IS NULL')
+            ->where('[[sortOrder]] IS NULL')
             ->column();
         $neoBlocks = Block::find()
             ->id($neoBlockIds)


### PR DESCRIPTION
Fixes the following breaking 2.8.15 error:

```
craft\errors\MigrationException: An error occurred while executing the "benf\neo\migrations\m201208_110049_delete_blocks_without_sort_order migration: SQLSTATE[42703]: Undefined column: 7 ERROR:  column "sortorder" does not exist
LINE 3: WHERE sortOrder IS NULL
              ^
HINT:  Perhaps you meant to reference the column "neoblocks.sortOrder".
```