### PR TITLE
Fix for draft change merging bug

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -652,10 +652,9 @@ class Field extends BaseField implements EagerLoadingFieldInterface, GqlInlineFr
         /** @var Element $element */
         if ($element->duplicateOf !== null) {
             Neo::$plugin->fields->duplicateBlocks($this, $element->duplicateOf, $element, true);
-        } else {
-            if ($element->isFieldDirty($this->handle) || !empty($element->newSiteIds)) {
-                Neo::$plugin->fields->saveValue($this, $element);
-            }
+            $resetValue = true;
+        } else if ($element->isFieldDirty($this->handle) || !empty($element->newSiteIds)) {
+            Neo::$plugin->fields->saveValue($this, $element);
         }
 
         // Repopulate the Neo block query if this is a new element

--- a/src/Field.php
+++ b/src/Field.php
@@ -649,16 +649,24 @@ class Field extends BaseField implements EagerLoadingFieldInterface, GqlInlineFr
      */
     public function afterElementPropagate(ElementInterface $element, bool $isNew)
     {
+        $resetValue = false;
+
         /** @var Element $element */
         if ($element->duplicateOf !== null) {
             Neo::$plugin->fields->duplicateBlocks($this, $element->duplicateOf, $element, true);
             $resetValue = true;
         } else if ($element->isFieldDirty($this->handle) || !empty($element->newSiteIds)) {
             Neo::$plugin->fields->saveValue($this, $element);
+        } else if (
+            ($status = $element->getFieldStatus($this->handle)) !== null &&
+            $status[0] === Element::ATTR_STATUS_OUTDATED
+        ) {
+            Neo::$plugin->fields->duplicateBlocks($this, ElementHelper::sourceElement($element), $element, true);
+            $resetValue = true;
         }
 
         // Repopulate the Neo block query if this is a new element
-        if ($element->duplicateOf || $isNew) {
+        if ($resetValue || $isNew) {
             $query = $element->getFieldValue($this->handle);
             $this->_populateQuery($query, $element);
             $query->clearCachedResult();


### PR DESCRIPTION
This PR copies the fix from craftcms/cms@dcb86ca0, where outdated Matrix blocks weren’t getting propagated to drafts when the “Merge changes into draft” button was clicked on the draft.