### PR TITLE
🐛 Fix a bug when saving Neo fields from console commands

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -592,7 +592,7 @@ class Field extends BaseField implements EagerLoadingFieldInterface, GqlInlineFr
         // will be `null`, `getGroups()` will return `Neo::$plugin->blockTypes->getGroupsByFieldId($this->id)` and the
         // groups won't be deleted.  By detecting this here, we can set an empty array of groups, so the to-be-deleted
         // groups will actually be deleted.
-        if ($requestService->getBodyParam("types.{$class}") !== null && $requestService->getBodyParam("types.{$class}.groups") === null) {
+        if (!$requestService->isConsoleRequest && $requestService->getBodyParam("types.{$class}") !== null && $requestService->getBodyParam("types.{$class}.groups") === null) {
             $this->setGroups([]);
         }
 


### PR DESCRIPTION
The error I had was: 

> Calling unknown method: craft\\console\\Request::getBodyParam()

Stack trace:

```
yii\base\UnknownMethodException#1
(
    [*:message] => 'Calling unknown method: craft\\console\\Request::getBodyParam()'
    [Exception:string] => ''
    [*:code] => 0
    [*:file] => '/var/www/html/craft/vendor/yiisoft/yii2/base/Component.php'
    [*:line] => 301
    [Exception:trace] => [
        0 => [
            'file' => '/var/www/html/craft/vendor/spicyweb/craft-neo/src/Field.php'
            'line' => 595
            'function' => '__call'
            'class' => 'yii\\base\\Component'
            'type' => '->'
            'args' => [
                0 => 'getBodyParam'
                1 => [
                    0 => 'types.benf\\neo\\Field'
                ]
            ]
        ]
        1 => [
            'file' => '/var/www/html/craft/vendor/craftcms/cms/src/services/Fields.php'
            'line' => 794
            'function' => 'beforeSave'
            'class' => 'benf\\neo\\Field'
            'type' => '->'
            'args' => [
                0 => true
            ]
        ]
        2 => [
            'file' => '/var/www/html/craft/modules/standardisation/src/services/ElementsService.php'
            'line' => 193
            'function' => 'saveField'
            'class' => 'craft\\services\\Fields'
            'type' => '->'
            'args' => [
                0 => benf\neo\Field#2
                (
                    [localizeBlocks] => true
                    [minBlocks] => null
                    [maxBlocks] => null
                    [maxTopBlocks] => null
                    [maxLevels] => null
                    [wasModified] => false
                    [benf\neo\Field:_blockTypes] => null
                    [benf\neo\Field:_blockTypeGroups] => null
                    [propagationMethod] => 'none'
                    [benf\neo\Field:_oldPropagationMethod] => null
                    [craft\base\Field:_isFresh] => null
                    [yii\base\Model:_errors] => null
                    [yii\base\Model:_validators] => null
                    [yii\base\Model:_scenario] => 'default'
                    [yii\base\Component:_events] => [...]
                    [yii\base\Component:_eventWildcards] => [...]
                    [yii\base\Component:_behaviors] => [...]
                    [id] => null
                    [dateCreated] => null
                    [dateUpdated] => null
                    [groupId] => 2
                    [name] => 'Blocs CMS'
                    [handle] => 'contentBuildersMain'
                    [context] => 'global'
                    [instructions] => null
                    [searchable] => false
                    [translationMethod] => 'site'
                    [translationKeyFormat] => null
                    [oldHandle] => null
                    [oldSettings] => null
                    [columnPrefix] => null
                    [uid] => null
                    [layoutId] => null
                    [tabId] => null
                    [required] => null
                    [sortOrder] => null
                )
            ]
        ]
        3 => [
            'file' => '/var/www/html/craft/modules/standardisation/src/featureinstallers/CmsInstaller.php'
            'line' => 28
            'function' => 'createField'
            'class' => 'modules\\standardisation\\services\\ElementsService'
            'type' => '->'
            'args' => [
                0 => 'Main'
                1 => craft\models\FieldGroup#3
                (
                    [id] => 2
                    [name] => 'Content builders'
                    [uid] => '85367aa7-ead9-41b5-9b41-cad4662e8eeb'
                    [yii\base\Model:_errors] => [...]
                    [yii\base\Model:_validators] => ArrayObject(...)
                    [yii\base\Model:_scenario] => 'default'
                    [yii\base\Component:_events] => [...]
                    [yii\base\Component:_eventWildcards] => [...]
                    [yii\base\Component:_behaviors] => [...]
                )
                2 => 'benf\\neo\\Field'
                3 => [
                    'id' => null
                    'type' => 'benf\\neo\\Field'
                    'groupId' => 2
                    'name' => 'Blocs CMS'
                    'handle' => 'contentBuildersMain'
                    'translationMethod' => 'site'
                    'localizeBlocks' => true
                    'propagationMethod' => 'none'
                ]
                4 => 'Blocs CMS'
            ]
        ]
        4 => [
            'file' => '/var/www/html/craft/modules/standardisation/src/console/controllers/InstallController.php'
            'line' => 496
            'function' => 'install'
            'class' => 'modules\\standardisation\\featureinstallers\\CmsInstaller'
            'type' => '->'
            'args' => []
        ]
        5 => [
            'file' => '/var/www/html/craft/modules/standardisation/src/console/controllers/InstallController.php'
            'line' => 106
            'function' => 'createContentPagesSection'
            'class' => 'modules\\standardisation\\console\\controllers\\InstallController'
            'type' => '->'
            'args' => []
        ]
        6 => [
            'file' => '/var/www/html/craft/modules/standardisation/src/console/controllers/InstallController.php'
            'line' => 59
            'function' => 'actionInstallCraft'
            'class' => 'modules\\standardisation\\console\\controllers\\InstallController'
            'type' => '->'
            'args' => []
        ]
        7 => [
            'function' => 'actionIndex'
            'class' => 'modules\\standardisation\\console\\controllers\\InstallController'
            'type' => '->'
            'args' => []
        ]
        8 => [
            'file' => '/var/www/html/craft/vendor/yiisoft/yii2/base/InlineAction.php'
            'line' => 57
            'function' => 'call_user_func_array'
            'args' => [
                0 => [
                    0 => modules\standardisation\console\controllers\InstallController(...)
                    1 => 'actionIndex'
                ]
                1 => []
            ]
        ]
        9 => [
            'file' => '/var/www/html/craft/vendor/yiisoft/yii2/base/Controller.php'
            'line' => 181
            'function' => 'runWithParams'
            'class' => 'yii\\base\\InlineAction'
            'type' => '->'
            'args' => [
                0 => []
            ]
        ]
        10 => [
            'file' => '/var/www/html/craft/vendor/yiisoft/yii2/console/Controller.php'
            'line' => 184
            'function' => 'runAction'
            'class' => 'yii\\base\\Controller'
            'type' => '->'
            'args' => [
                0 => ''
                1 => []
            ]
        ]
        11 => [
            'file' => '/var/www/html/craft/vendor/yiisoft/yii2/base/Module.php'
            'line' => 534
            'function' => 'runAction'
            'class' => 'yii\\console\\Controller'
            'type' => '->'
            'args' => [
                0 => ''
                1 => []
            ]
        ]
        12 => [
            'file' => '/var/www/html/craft/vendor/yiisoft/yii2/console/Application.php'
            'line' => 181
            'function' => 'runAction'
            'class' => 'yii\\base\\Module'
            'type' => '->'
            'args' => [
                0 => 'standardisation-module/install'
                1 => []
            ]
        ]
        13 => [
            'file' => '/var/www/html/craft/vendor/craftcms/cms/src/console/Application.php'
            'line' => 89
            'function' => 'runAction'
            'class' => 'yii\\console\\Application'
            'type' => '->'
            'args' => [
                0 => 'standardisation-module/install'
                1 => []
            ]
        ]
        14 => [
            'file' => '/var/www/html/craft/vendor/yiisoft/yii2/console/Application.php'
            'line' => 148
            'function' => 'runAction'
            'class' => 'craft\\console\\Application'
            'type' => '->'
            'args' => [
                0 => 'standardisation-module/install'
                1 => []
            ]
        ]
        15 => [
            'file' => '/var/www/html/craft/vendor/yiisoft/yii2/base/Application.php'
            'line' => 392
            'function' => 'handleRequest'
            'class' => 'yii\\console\\Application'
            'type' => '->'
            'args' => [
                0 => craft\console\Request#4
                (
                    [yii\console\Request:_params] => [...]
                    [yii\base\Request:_scriptFile] => '/var/www/html/craft/craft'
                    [yii\base\Request:_isConsoleRequest] => true
                    [yii\base\Component:_events] => [...]
                    [yii\base\Component:_eventWildcards] => [...]
                    [yii\base\Component:_behaviors] => [...]
                    [isWebrootAliasSetDynamically] => true
                    [isWebAliasSetDynamically] => true
                )
            ]
        ]
        16 => [
            'file' => '/var/www/html/craft/craft'
            'line' => 22
            'function' => 'run'
            'class' => 'yii\\base\\Application'
            'type' => '->'
            'args' => []
        ]
    ]
) 
```