### PR TITLE
Allow `fieldLayoutId` to be present in the blockType config when calling `setBlockTypes()`

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -234,6 +234,14 @@ class Field extends BaseField implements EagerLoadingFieldInterface, GqlInlineFr
                 $newBlockType->topLevel = (bool)$blockType['topLevel'];
                 $newBlockType->childBlocks = $blockType['childBlocks'];
                 $newBlockType->sortOrder = (int)$blockType['sortOrder'];
+                
+                // Allow the `fieldLayoutId` to be set in the blockType settings
+                if ($fieldLayoutId = ($blockType['fieldLayoutId'] ?? null)) {
+                    if ($fieldLayout = Craft::$app->getFields()->getLayoutById($fieldLayoutId)) {
+                        $newBlockType->setFieldLayout($fieldLayout);
+                        $newBlockType->fieldLayoutId = $fieldLayout->id;
+                    }
+                }
 
                 if (!empty($blockType['elementPlacements'])) {
                     $fieldLayout = $fieldsService->assembleLayoutFromPost('types.' . self::class . ".blockTypes.{$blockTypeId}");

--- a/src/Field.php
+++ b/src/Field.php
@@ -237,7 +237,7 @@ class Field extends BaseField implements EagerLoadingFieldInterface, GqlInlineFr
                 
                 // Allow the `fieldLayoutId` to be set in the blockType settings
                 if ($fieldLayoutId = ($blockType['fieldLayoutId'] ?? null)) {
-                    if ($fieldLayout = Craft::$app->getFields()->getLayoutById($fieldLayoutId)) {
+                    if ($fieldLayout = $fieldsService->getLayoutById($fieldLayoutId)) {
                         $newBlockType->setFieldLayout($fieldLayout);
                         $newBlockType->fieldLayoutId = $fieldLayout->id;
                     }


### PR DESCRIPTION
This is a compatibility fix with [Field Manager](https://github.com/verbb/field-manager/issues/79).

Because Neo now relies on `assembleLayoutFromPost()`, Field Manager is unable to import the settings for a Neo field from JSON, because it is heavily tied to POST data. So, instead, Field Manager creates and saves the field layout on-import, saves this to a `fieldLayoutId` property in the block type config, and then applies that.

I'm going to also maybe submit a PR to Craft for an alternative to `assembleLayoutFromPost()` that doesn't rely on POST params, so it's a bit more reusable.