### PR TITLE
Block Type Filter Event

### DIFF
--- a/src/assets/FieldAsset.php
+++ b/src/assets/FieldAsset.php
@@ -48,6 +48,7 @@ class FieldAsset extends AssetBundle
      *     }
      *
      *     $event->blockTypes = $filtered;
+     * });
      *
      */
     const EVENT_FILTER_BLOCK_TYPES = "filterBlockTypes";

--- a/src/assets/FieldAsset.php
+++ b/src/assets/FieldAsset.php
@@ -2,6 +2,7 @@
 
 namespace benf\neo\assets;
 
+use benf\neo\events\FilterBlockTypesEvent;
 use Craft;
 use craft\base\ElementInterface;
 use craft\fieldlayoutelements\CustomField;
@@ -16,6 +17,7 @@ use benf\neo\fieldlayoutelements\ChildBlocksUiElement;
 use benf\neo\models\BlockType;
 use benf\neo\models\BlockTypeGroup;
 use benf\neo\elements\Block;
+use yii\base\Event;
 
 /**
  * Class FieldAsset
@@ -27,6 +29,29 @@ use benf\neo\elements\Block;
  */
 class FieldAsset extends AssetBundle
 {
+    /**
+     * Event that allows filtering what block types are available for a given field.
+     *
+     * @event FilterBlockTypesEvent
+     *
+     * ```php
+     * use benf\neo\assets\FieldAsset;
+     * use benf\neo\events\FilterBlockTypesEvent;
+     * use yii\base\Event;
+     *
+     * Event::on(FieldAsset::class, FieldAsset::EVENT_FILTER_BLOCK_TYPES, function (FilterBlockTypesEvent $event) {
+     *     $filtered = [];
+     *     foreach ($event->blockTypes as $type) {
+     *         if ($type->handle === 'cards') {
+     *             $filtered[] = $type;
+     *         }
+     *     }
+     *
+     *     $event->blockTypes = $filtered;
+     *
+     */
+    const EVENT_FILTER_BLOCK_TYPES = "filterBlockTypes";
+
     /**
      * @inheritdoc
      */
@@ -151,11 +176,18 @@ class FieldAsset extends AssetBundle
         $blockTypes = $field->getBlockTypes();
         $blockTypeGroups = $field->getGroups();
         
+        $event = new FilterBlockTypesEvent([
+            'field' => $field,
+            'blockTypes' => $blockTypes,
+            'blockTypeGroups' => $blockTypeGroups
+        ]);
+        Event::trigger(self::class, self::EVENT_FILTER_BLOCK_TYPES, $event);
+
         $jsSettings = [
             'name' => $name,
             'namespace' => $viewService->namespaceInputName($name) . '[blocks]',
-            'blockTypes' => self::_getBlockTypesJsSettings($blockTypes, true, $static, $siteId, $owner),
-            'groups' => self::_getBlockTypeGroupsJsSettings($blockTypeGroups),
+            'blockTypes' => self::_getBlockTypesJsSettings($event->blockTypes, true, $static, $siteId, $owner),
+            'groups' => self::_getBlockTypeGroupsJsSettings($event->blockTypeGroups),
             'inputId' => $viewService->namespaceInputId($id),
             'minBlocks' => $field->minBlocks,
             'maxBlocks' => $field->maxBlocks,

--- a/src/assets/FieldAsset.php
+++ b/src/assets/FieldAsset.php
@@ -179,6 +179,7 @@ class FieldAsset extends AssetBundle
         
         $event = new FilterBlockTypesEvent([
             'field' => $field,
+            'element' => $owner,
             'blockTypes' => $blockTypes,
             'blockTypeGroups' => $blockTypeGroups
         ]);

--- a/src/events/FilterBlockTypesEvent.php
+++ b/src/events/FilterBlockTypesEvent.php
@@ -3,11 +3,15 @@
 namespace benf\neo\events;
 
 use benf\neo\Field;
+use craft\base\ElementInterface;
 
 class FilterBlockTypesEvent extends \yii\base\Event
 {
     /** @var Field */
     public $field;
+
+    /** @var ElementInterface */
+    public $element;
 
     /** @var array */
     public $blockTypes;

--- a/src/events/FilterBlockTypesEvent.php
+++ b/src/events/FilterBlockTypesEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace benf\neo\events;
+
+use benf\neo\Field;
+
+class FilterBlockTypesEvent extends \yii\base\Event
+{
+    /** @var Field */
+    public $field;
+
+    /** @var array */
+    public $blockTypes;
+
+    /** @var array */
+    public $blockTypeGroups;
+}


### PR DESCRIPTION
This pull request addresses #114 by adding an event to the `benf\neo\assets\FieldAsset` class, which allows developers to control which block types are displayed on the field input view.

Adding an event to the `FieldAsset` class scopes this functionality to just element edit views. It also seemed like the best place to put this event since the `createInputJs` function is only called on whenever the input field is being rendered. 

Here's an example of how this event might be used. 

```php
        Event::on(FieldAsset::class, FieldAsset::EVENT_FILTER_BLOCK_TYPES, function (FilterBlockTypesEvent $event) {
           if (is_a($event->element, Entry::class) && $event->element->section->handle === 'foo') {
              $filtered = [];
              foreach ($event->blockTypes as $type) {
                  if ($type->handle === 'cards') {
                      $filtered[] = $type;
                  }
              }
              $event->blockTypes = $filtered;
            }
        });
```

The field instance is passed into the event, as well as the element, which should allow filtering based on various criteria. 

Would love feedback on this approach!
