### PR TITLE
fix: An error when running the craft console command

### DIFF
--- a/src/console/controllers/FieldsController.php
+++ b/src/console/controllers/FieldsController.php
@@ -35,7 +35,7 @@ class FieldsController extends Controller
     /**
      * @inheritdoc
      */
-    public function options($actionID)
+    public function options($actionID): array
     {
         $options = parent::options($actionID);
 


### PR DESCRIPTION
> Error: Declaration of benf\neo\console\controllers\FieldsController::options($actionID) must be compatible with craft\console\Controller::options($actionID): array