### PR TITLE
Add `data-neo-b-name` to the `ni_block`

### DIFF
--- a/client/src/input/Block.js
+++ b/client/src/input/Block.js
@@ -147,7 +147,7 @@ export default Garnish.Base.extend({
     const tabsMenuId = `neoblock-tabs-menu-${this._id}`
     const elementHtml = []
     elementHtml.push(`
-      <div class="ni_block ni_block--${type.getHandle()} is-${this._collapsed ? 'collapsed' : 'expanded'} ${!hasTabs && !isParent ? 'is-empty' : ''} ${isParent ? 'is-parent' : ''}" data-neo-b-id="${this._id}">
+      <div class="ni_block ni_block--${type.getHandle()} is-${this._collapsed ? 'collapsed' : 'expanded'} ${!hasTabs && !isParent ? 'is-empty' : ''} ${isParent ? 'is-parent' : ''}" data-neo-b-id="${this._id}  data-neo-b-name="${type.getName()}">
         <input type="hidden" name="${baseInputName}[type]" value="${type.getHandle()}">
         <input type="hidden" name="${baseInputName}[enabled]" value="${this._enabled ? '1' : ''}" data-neo-b="${this._id}.input.enabled">
         <input type="hidden" name="${baseInputName}[level]" value="${this._level}" data-neo-b="${this._id}.input.level">

--- a/src/templates/block.twig
+++ b/src/templates/block.twig
@@ -16,6 +16,7 @@
     ],
     data: {
         'neo-b-id': blockId,
+        'neo-b-name': "#{type.name}",
     },
 } %}
 


### PR DESCRIPTION
We use CPSS very much to extend/style our NEO Builders.
The data-attr would be very helpful to do things like: `content: attr(data-neo-b-name);` for custom labels on the blocks. It's a bit sugar and has no side effects I think.