### PR TITLE
Add `uid` handling for Neo blocks when converting from serialized blocks

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -1480,6 +1480,11 @@ class Field extends BaseField implements EagerLoadingFieldInterface, GqlInlineFr
                 $block->setCollapsed((bool)$blockData['collapsed']);
             }
 
+            // Allow setting the UID for the block element
+            if (isset($blockData['uid'])) {
+                $block->uid = $blockData['uid'];
+            }
+
             // Skip disabled blocks on Live Preview requests
             if ($hideDisabledBlocks && !$block->enabled) {
                 continue;


### PR DESCRIPTION
Similar to https://github.com/craftcms/cms/pull/13089 this is to add support to [Zen](https://github.com/verbb/zen) which uses UIDs for blocks (their element UID) between installs to compare.

For Neo blocks, I have the usual serialized data to supply to `element->setFieldValues()`.

```php
[
    'new1' => [
        'type' => 'contentBlock'
        'enabled' => true
        'collapsed' => false
        'uid' => 'd02d03e9-9677-466b-b8ac-0374890ba5a4'
        'fields' => [
            'plainText' => 'someText'
        ]
    ]
]
```

You can see I've added the `uid` there for the `Block` element in hopes that it would populate the element (it doesn't without this change). With this content populated the block will get created, but a brand new UID would be generated, and this one dicarded. 

If I run this code again (populate the element with `setFieldValues()`), this would create a duplicate block. That's because the only way to control this is through the array index `new1` which would be replaced by the block ID. As you know, the `newX` notation defines new blocks. But, because this content is coming from another install, it's impossible to consolidate that ID, when content is coming from another install.

With this change, blocks can at least have their UID set so it's not reliant on the `new` or ID index. In this way, when the block is created, it's created with the UID we specify, and can be used again to lookup the value.