### PR TITLE
Fix syntax error for block's checkbox

### DIFF
--- a/src/assets/src/input/Block.js
+++ b/src/assets/src/input/Block.js
@@ -177,7 +177,7 @@ export default Garnish.Base.extend({
         <div class="ni_block_topbar" data-neo-b="${this._id}.container.topbar">
           <div class="ni_block_topbar_left" data-neo-b="${this._id}.container.topbarLeft">
             <div class="ni_block_topbar_item" data-neo-b="${this._id}.select">
-              <div class="checkbox block-checkbox" title="${Craft.t('neo', 'Select')} aria-label="${Craft.t('neo', 'Select')}"></div>
+              <div class="checkbox block-checkbox" title="${Craft.t('neo', 'Select')}" aria-label="${Craft.t('neo', 'Select')}"></div>
             </div>
             <div class="ni_block_topbar_item title">
               <span class="blocktype" data-neo-b="${this._id}.select">${type.getName()}</span>


### PR DESCRIPTION
There's invalid HTML generated, which while seemingly fine for browsers to figure out, causes mayhem with Vue and Vizy.

<img width="577" alt="Screenshot 2023-12-08 at 12 41 14 am" src="https://github.com/spicywebau/craft-neo/assets/1221575/a77cd373-bfb5-4d4a-92c8-a50eac210f38">

```html
<div class="checkbox block-checkbox" title="Select aria-label=" select"=""></div>
```

And should be 

```html
<div class="checkbox block-checkbox" title="Select" aria-label="Select"></div>
```