### PR TITLE
Stops clearing errors already applied to neo blocks

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -851,7 +851,7 @@ class Field extends BaseField implements EagerLoadingFieldInterface, GqlInlineFr
                 $block->setScenario($scenario);
             }
 
-            if (!$block->validate()) {
+            if (!$block->validate(clearErrors:false)) {
                 $element->addModelErrors($block, "{$this->handle}[{$key}]");
                 $allBlocksValidate = false;
             }


### PR DESCRIPTION
When custom errors have been applied to neo blocks via events (for example Entry::EVENT_DEFINE_RULES), this call to validate blocks removes them. This change retains existing errors while allowing Neo to include its own.

Unsure if this is the correct way to go about this, I couldn't understand why none of my errors was displaying on the block, but model errors were fine. I traced it back to this and found that calling block validate was stripping them out.