### PR TITLE
Require ownerId before saving drafts

### DIFF
--- a/src/controllers/Input.php
+++ b/src/controllers/Input.php
@@ -146,14 +146,15 @@ class Input extends Controller
                 $block->setFieldValues($rawBlock['content']);
             }
 
-            if (!$elementsService->canSave($block, $user)) {
+            if ($ownerId && !$elementsService->canSave($block, $user)) {
                 throw new ForbiddenHttpException('User not authorized to create this element.');
             }
 
             $block->setScenario(Element::SCENARIO_ESSENTIALS);
-            $draftsService->saveElementAsDraft($block, $user->id, markAsSaved: false);
 
             if ($ownerId) {
+               $draftsService->saveElementAsDraft($block, $user->id, markAsSaved: false);
+               
                 // If the owner supports drafts, temporarily save the block's position in the block structure before
                 // rendering the block template, so the block template shows the correct visible field layout elements
                 $structure = $elementsService->canCreateDrafts($block->getOwner())


### PR DESCRIPTION
Calls to the render-blocks action will fail if there is no ownerId.

This does not occur with entries, but for other Elements such as a Solspace Calendar Plugin "Event" Element there is no Element / Owner Id at the time a new one is created.

These conditionals should fix that.