### PR TITLE
Fix read-only child blocks UID split (#1036)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Fixed a bug where Neo blocks with a child blocks UI element rendered HTML-encoded markup that broke the layout when the field was rendered in a read-only / static context ([#1036](https://github.com/spicywebau/craft-neo/issues/1036))
+
 ## 5.5.10 - 2026-06-02
 
 ### Fixed

--- a/src/templates/block.twig
+++ b/src/templates/block.twig
@@ -352,10 +352,17 @@
                     {% set splitOnChildBlocks = renderedForm|split('<div data-neo-child-blocks-ui-element="' ~ blockId ~ '" data-layout-element="') %}
                     {{ splitOnChildBlocks[0]|raw }}
                     {% if splitOnChildBlocks|length > 1 %}
-                        {% set splitAfterChildBlocks = splitOnChildBlocks[1]|split('"></div>', 2) %}
-                        {% if splitAfterChildBlocks|length == 1 %}
-                            {% set splitAfterChildBlocks = splitOnChildBlocks[1]|split('" data-static></div>', 2) %}
-                        {% endif %}
+                        {#
+                            The placeholder closing tag differs by render mode:
+                              - dynamic: ...data-layout-element="UID"></div>
+                              - static:  ...data-layout-element="UID" data-static></div>
+                            Pick the delimiter from the known `static` flag. Don't infer it from the split
+                            length: a `"></div>` can appear deeper in a later field's markup, which falsely
+                            matches the dynamic delimiter in static mode and swallows the rest of the form
+                            into `uid` (rendered as encoded `&quot;`/`&gt;` garbage). See #1036.
+                        #}
+                        {% set childBlocksUiClose = static ? '" data-static></div>' : '"></div>' %}
+                        {% set splitAfterChildBlocks = splitOnChildBlocks[1]|split(childBlocksUiClose, 2) %}
 
                         {% include 'neo/child-blocks' with { block, handle, static, uid: splitAfterChildBlocks[0] } %}
                         {{ errorList }}


### PR DESCRIPTION
Fixes #1036.

### Problem

When a Neo field containing a child blocks UI element is rendered in a read-only / static context, the control panel layout breaks: the placeholder is replaced with HTML-encoded markup (`&quot;`, `&gt;`, `&lt;`) instead of the actual child blocks.

### Root cause

The child blocks UI element placeholder closes with a different tag depending on how the field layout form was rendered (`FieldLayout::createForm($block, $static)`):

- **dynamic:** `…data-layout-element="UID"></div>`
- **static:** `…data-layout-element="UID" data-static></div>`

`block.twig` inferred which case applied from the length of `split('"></div>', 2)`:

```twig
{% set splitAfterChildBlocks = splitOnChildBlocks[1]|split('"></div>', 2) %}
{% if splitAfterChildBlocks|length == 1 %}
    {% set splitAfterChildBlocks = splitOnChildBlocks[1]|split('" data-static></div>', 2) %}
{% endif %}
```

That inference is unsound. In static mode there is no `"></div>` *at the placeholder* (it closes with `" data-static></div>`), but a `"></div>` almost always appears **deeper inside a later field's markup** (e.g. `class="field width-100"></div>`). So the first split still returns two parts, `length == 1` is false, and the `" data-static></div>` fallback never runs.

`splitAfterChildBlocks[0]` (passed as `uid`) then becomes the entire remainder of the form HTML, which `neo/child-blocks` emits as `data-layout-element="{{ uid }}"` — Twig auto-escaping turns the embedded markup into the encoded garbage that breaks the layout. Dynamic mode is unaffected because the first `"></div>` in the remainder *is* the placeholder close.

### Fix

Choose the delimiter from the `static` flag already in scope, instead of guessing from split length. Deterministic in both render modes and can't be fooled by a `"></div>` elsewhere in the form.

### Testing

Verified on Neo 5.5.10 / Craft 5.10.5:
- Read-only / static render: placeholder is now correctly replaced with child blocks; `data-layout-element` is a clean UID; no encoded markup.
- Editable / dynamic render: unchanged, still renders correctly.
